### PR TITLE
kodi: Build Kodi for the Raspberry Pi

### DIFF
--- a/recipes-multimedia/kodi/kodi_%.bbappend
+++ b/recipes-multimedia/kodi/kodi_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "raspberrypi"


### PR DESCRIPTION
This adds "raspberrypi" to the PACKAGECONFIG variable, which tells bitbake that Kodi should be built for the Raspberry Pi.

**- What I did**

I added "raspberrypi" to PACKAGECONFIG, which tells bitbake to build Kodi for the Raspberry Pi.

**- How I did it**

See commit.