### PR TITLE
Upgrade to Yocto Warrior

### DIFF
--- a/conf/machine/include/rpi-base.inc
+++ b/conf/machine/include/rpi-base.inc
@@ -70,7 +70,7 @@ KERNEL_IMAGETYPE_DIRECT ??= "zImage"
 KERNEL_IMAGETYPE ?= "${@bb.utils.contains('RPI_USE_U_BOOT', '1', \
         '${KERNEL_IMAGETYPE_UBOOT}', '${KERNEL_IMAGETYPE_DIRECT}', d)}"
 
-MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio vc4graphics"
+MACHINE_FEATURES += "apm usbhost keyboard vfat ext2 screen touchscreen alsa bluetooth wifi sdio"
 
 # Raspberry Pi has no hardware clock
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"


### PR DESCRIPTION
## Description

Over the weekend, I rebased this repo on the upstream `warrior` branch. Kodi broke, and I tracked the breakage down to this commit.

Kodi build fails due to missing `eglCreateImageKHR()`. My guess is that `vc4graphics` changed EGL versions.

## How has this been tested?

Compiled Kodi 18.4 on RPi 3 and ran it.
