### PR TITLE
Fix broken Yocto 2.7 Warrior build

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-kernel/linux/bpftool.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-kernel/linux/bpftool.bbappend
@@ -1,3 +1,0 @@
-# remove it when we upgrade to kernel > 4.14
-#
-COMPATIBLE_HOST_rpi = "null"

--- a/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION ?= "4.14.81"
-
-SRCREV = "acf578d07d57480674d5361df9171fe9528765cb"
-SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y-rt \
-    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
-    "
-
-require linux-raspberrypi.inc

--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION ?= "4.14.112"
-
-SRCREV = "6b5c4a2508403839af29ef44059d04acbe0ee204"
-SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
-    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
-    "
-
-require linux-raspberrypi.inc


### PR DESCRIPTION
## Description

Backport of https://github.com/eigendude/meta-raspberrypi/pull/4.

Currently, Raspberry Pi fails to build against warrior. This is because meta-ros sets a preferred version for the kernel of 4.14, but the config in this repo is broken for 4.14 so it fails to build.

To fix this, we simply remove 4.14, which guarantees that we don't build against it in the future.

## How has this been tested?

Tried to build before the patch. Error was:

```
| make[3]: *** No rule to make target 'arch/arm/boot/dts/bcm2708-rpi-zero-w.dtb'.  Stop.
```

Tried to build after the patch. Success!