### PR TITLE
Fix broken Yocto 3.0 Zeus build

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi-rt_4.14.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION ?= "4.14.91"
-
-SRCREV = "0b520d5f1f580d36a742a9457a5673fa1578fff3"
-SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y-rt \
-    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
-    "
-
-require linux-raspberrypi.inc

--- a/recipes-kernel/linux/linux-raspberrypi_4.14.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.14.bb
@@ -1,9 +1,0 @@
-LINUX_VERSION ?= "4.14.114"
-
-SRCREV = "7688b39276ff9952df381d79de63b258e73971ce"
-SRC_URI = " \
-    git://github.com/raspberrypi/linux.git;branch=rpi-4.14.y \
-    file://0001-menuconfig-check-lxdiaglog.sh-Allow-specification-of.patch \
-    "
-
-require linux-raspberrypi.inc


### PR DESCRIPTION
## Description

Currently, Raspberry Pi fails to build against Yocto Zeus. This is because meta-ros sets a preferred version for the kernel of 4.14, but the config in this repo is broken for 4.14 so it fails to build.

To fix this, we simply remove 4.14, which guarantees that we don't build against it in the future.

## How has this been tested?

Tried to build before the patch. Error was:

```
| make[3]: *** No rule to make target 'arch/arm/boot/dts/bcm2708-rpi-zero-w.dtb'.  Stop.
```

Tried to build after the patch. Success!

Tested further as part of https://github.com/Aclima/sundstrom-os/pull/25